### PR TITLE
'fix:models for using uvicorn command'

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, String, Text, ForeignKey, DateTime, Enum, JSON
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
-from backend.database import Base
+from database import Base
 import enum
 import uuid
 from datetime import datetime


### PR DESCRIPTION
# FastAPI実行時にmodel.pyのパスの指定を変更

- Alembicでデータベースを編集する際には再び`import backend.database from Base`を指定する必要があるかもしれない